### PR TITLE
dcm-select2 - change restriction for input type hidden

### DIFF
--- a/src/select2/directives/dcmSelect2.js
+++ b/src/select2/directives/dcmSelect2.js
@@ -38,7 +38,7 @@ angular.module('dcm-ui.select2')
       transclude: false,
       compile: function compile(tElement) { // tElement , tAttrs, transclude
 
-        if (!tElement.is('input[type=hidden]')) {
+        if (!tElement.is('[type=hidden]')) {
           throw('only <input type="hidden"> tags can have this attribute');
         }
 


### PR DESCRIPTION
dcm-select2 - Change restriction from input[type=hidden] to just [type=hidden] to allow for use with other element directives.

I can came across this issue when trying to add select2 support to a form input directive.

@njs50 Could you please review when you get a chance?