### PR TITLE
updated to support angular 1.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "angular": "~1.3.2",
-    "angular-mocks": "~1.3.2",
+    "angular": "~1.4",
+    "angular-mocks": "~1.4",
     "jquery": "~2.1.0",
     "bootstrap": "~3.1.1",
     "fontawesome": "~4.0.3",
@@ -24,9 +24,9 @@
     "marked": "~0.3.2",
     "google-code-prettify": "~1.0.1",
     "select2": "~3.4.8",
-    "select2-bootstrap-css": "git://github.com/njs50/select2-bootstrap-css.git#1.3.0"
+    "select2-bootstrap-css": "1.4.6"
   },
   "resolutions": {
-    "angular": "1.3.2"
+    "angular": "~1.4"
   }
 }

--- a/src/grid/directives/dcmGridColumnDirective.js
+++ b/src/grid/directives/dcmGridColumnDirective.js
@@ -50,7 +50,7 @@ angular.module('dcm-ui.grid')
           // copy over any attributes that aren't in our scope
           var attributes = {};
           angular.forEach(attrs, function(obj, key){
-            if (key[0] !== '$' && !scope.hasOwnProperty(key) && attrs[key] !== '') {
+            if (key[0] !== '$' && ( !scope.hasOwnProperty(key) || scope[key] === undefined ) && obj !== '') {
               attributes[key.replace(/([A-Z])/g,'-$1').toLowerCase()] = obj;
             }
           });
@@ -58,13 +58,13 @@ angular.module('dcm-ui.grid')
           var col = {
             content: content,
             attributes: attributes,
-            enabled: attrs.hasOwnProperty('enabled') ? (scope.enabled.toLowerCase() !== 'false') : true,
+            enabled: attrs.enabled !== undefined ? (attrs.enabled.toLowerCase() !== 'false') : true,
             title: scope.title,
             width: scope.width,
-            resizable: attrs.hasOwnProperty('resizable') ? (scope.resizable.toLowerCase() !== 'false') : true,
+            resizable: attrs.resizable !== undefined ? (attrs.resizable.toLowerCase() !== 'false') : true,
             field: attrs.field,
             sortType: scope.sortType || '',
-            sortDefault: attrs.hasOwnProperty('sortDefault') ? attrs.sortDefault || 'ASC' : false
+            sortDefault: attrs.sortDefault !== undefined ? attrs.sortDefault || 'ASC' : false
           };
 
           // if no field is specified try and infer it from the content

--- a/src/grid/directives/dcmGridColumnDirective.js
+++ b/src/grid/directives/dcmGridColumnDirective.js
@@ -50,7 +50,7 @@ angular.module('dcm-ui.grid')
           // copy over any attributes that aren't in our scope
           var attributes = {};
           angular.forEach(attrs, function(obj, key){
-            if (key[0] !== '$' && ( !scope.hasOwnProperty(key) || scope[key] === undefined ) && obj !== '') {
+            if (key[0] !== '$' && scope[key] === undefined && obj !== '') {
               attributes[key.replace(/([A-Z])/g,'-$1').toLowerCase()] = obj;
             }
           });

--- a/src/grid/directives/dcmGridRowActionsDirective.js
+++ b/src/grid/directives/dcmGridRowActionsDirective.js
@@ -36,7 +36,7 @@ angular.module('dcm-ui.grid')
           // copy over any attributes that aren't in our scope
           var attributes = {};
           angular.forEach(attrs, function(obj, key){
-            if (key[0] !== '$' && !scope.hasOwnProperty(key) && attrs[key] !== '') {
+            if (key[0] !== '$' && ( !scope.hasOwnProperty(key) || scope[key] === undefined ) && obj !== '') {
               attributes[key.replace(/([A-Z])/g,'-$1').toLowerCase()] = obj;
             }
           });

--- a/src/grid/directives/dcmGridRowActionsDirective.js
+++ b/src/grid/directives/dcmGridRowActionsDirective.js
@@ -36,7 +36,7 @@ angular.module('dcm-ui.grid')
           // copy over any attributes that aren't in our scope
           var attributes = {};
           angular.forEach(attrs, function(obj, key){
-            if (key[0] !== '$' && ( !scope.hasOwnProperty(key) || scope[key] === undefined ) && obj !== '') {
+            if (key[0] !== '$' && scope[key] === undefined && obj !== '') {
               attributes[key.replace(/([A-Z])/g,'-$1').toLowerCase()] = obj;
             }
           });

--- a/src/grid/directives/dcmGridRowDirective.js
+++ b/src/grid/directives/dcmGridRowDirective.js
@@ -29,7 +29,7 @@ angular.module('dcm-ui.grid')
           // copy over any attributes that aren't in our scope
           var attributes = {};
           angular.forEach(attrs, function(obj, key){
-            if (key[0] !== '$' && ( !scope.hasOwnProperty(key) || scope[key] === undefined ) && obj !== '') {
+            if (key[0] !== '$' && scope[key] === undefined && obj !== '') {
               attributes[key.replace(/([A-Z])/g,'-$1').toLowerCase()] = obj;
             }
           });

--- a/src/grid/directives/dcmGridRowDirective.js
+++ b/src/grid/directives/dcmGridRowDirective.js
@@ -29,7 +29,7 @@ angular.module('dcm-ui.grid')
           // copy over any attributes that aren't in our scope
           var attributes = {};
           angular.forEach(attrs, function(obj, key){
-            if (key[0] !== '$' && !scope.hasOwnProperty(key) && attrs[key] !== '') {
+            if (key[0] !== '$' && ( !scope.hasOwnProperty(key) || scope[key] === undefined ) && obj !== '') {
               attributes[key.replace(/([A-Z])/g,'-$1').toLowerCase()] = obj;
             }
           });

--- a/src/multiple-input/directives/multipleInput.js
+++ b/src/multiple-input/directives/multipleInput.js
@@ -85,14 +85,14 @@ angular.module('dcm-ui.multiple-input')
       }
 
       // if no input type is specified default it to text
-      if (!tAttrs.hasOwnProperty('addButtonLabel')) {
+      if (tAttrs.addButtonLabel === undefined || !tAttrs.hasOwnProperty('addButtonLabel')) {
         tAttrs.$set('addButtonLabel', 'Add Item');
       }
 
 
       // remove optional attributes of not specified
       angular.forEach(['ngPattern', 'ngMinlength', 'ngMaxlength', 'placeholder'], function(attr){
-        if (!tAttrs.hasOwnProperty(attr)) {
+        if (!tAttrs.hasOwnProperty(attr) || tAttrs[attr] === undefined) {
           inputEl.removeAttr(attr.replace(/([A-Z])/g,'-$1').toLowerCase());
         }
       });

--- a/src/multiple-input/directives/multipleInput.js
+++ b/src/multiple-input/directives/multipleInput.js
@@ -85,14 +85,14 @@ angular.module('dcm-ui.multiple-input')
       }
 
       // if no input type is specified default it to text
-      if (tAttrs.addButtonLabel === undefined || !tAttrs.hasOwnProperty('addButtonLabel')) {
+      if (tAttrs.addButtonLabel === undefined) {
         tAttrs.$set('addButtonLabel', 'Add Item');
       }
 
 
       // remove optional attributes of not specified
       angular.forEach(['ngPattern', 'ngMinlength', 'ngMaxlength', 'placeholder'], function(attr){
-        if (!tAttrs.hasOwnProperty(attr) || tAttrs[attr] === undefined) {
+        if (tAttrs[attr] === undefined) {
           inputEl.removeAttr(attr.replace(/([A-Z])/g,'-$1').toLowerCase());
         }
       });


### PR DESCRIPTION
backwards compatible with angular 1.3

For the most part everything just worked. The only changes needed were to support the way that angular 1.4 implements missing attributes. In angular 1.3 missing attributes would also be missing in the attributes object that gets passed into directives. In 1.4 those attributes are now present, but set to undefined. Where the presence (or absence) of an attribute was used to trigger logic the library needs to check for 1.3 and 1.4 style missing attributes.