### PR TITLE
Change to prevent a row from being activated twice when clicked on.

### DIFF
--- a/src/grid/controllers/dcmGridController.js
+++ b/src/grid/controllers/dcmGridController.js
@@ -616,7 +616,9 @@ angular.module('dcm-ui.grid')
         row.prepend(angular.element('<th class="dcm-grid-activemarker"></th>'));
 
         $scope.$watch('activeRow', function(data, previousRow){
-          ctrl.removeActiveRow(previousRow);
+          if(previousRow !== undefined) {
+            ctrl.removeActiveRow(previousRow);
+          }
           ctrl.setActiveRow(data);
         });
 

--- a/src/grid/directives/dcmGridDirective.js
+++ b/src/grid/directives/dcmGridDirective.js
@@ -243,9 +243,9 @@ angular.module('dcm-ui.grid')
               var selection = $window.getSelection().toString();
               if(!selection){
                 if (scope.activeRow === $row.data) {
-                  ctrl.removeActiveRow();
+                  scope.activeRow = undefined;
                 } else {
-                  ctrl.setActiveRow($row.data);
+                  scope.activeRow = $row.data;
                 }
               }
             };


### PR DESCRIPTION
Before this change, a row was activated in toggleActiveRow of the dcmGridDirective, which activated the watch on activeRow in the dcmGridController, causing it to be activated again.

Now, toggleActiveRow simply changes scope.activeRow, which triggers the watch, which handles activating the row.